### PR TITLE
chore: publish to npm feed instead of github

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish npm package
         run: yarn npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         uses: actions/create-release@v1

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-npmAuthToken: "${NODE_AUTH_TOKEN:-}"
+npmAuthToken: "${NPM_TOKEN:-}"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs

--- a/README.md
+++ b/README.md
@@ -2,34 +2,11 @@
 
 Design tokens generated from Figma.
 
-## Installation
-
-- [Acquire a GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The only permission you need to grant is `read:packages`
-- Assign the PAT to the `GITHUB_PACKAGES_PAT` environment variable:
-  - Mac/Linux: add the line `export GITHUB_PACKAGES_PAT=<PAT>` to `~/.bash_profile` and restart the terminal
-  - Windows: Run `setx GITHUB_PACKAGES_PAT <PAT> /m` and restart the terminal
-
 ### Yarn 2+
-
-In `.yarnrc`:
-
-```yaml
-npmScopes:
-  altinn:
-    npmRegistryServer: https://npm.pkg.github.com
-    npmAuthToken: ${GITHUB_PACKAGES_PAT:-}
-```
 
 Run `yarn add @altinn/figma-design-tokens`
 
-### NPM / Yarn 1
-
-In `.npmrc`:
-
-```plain
-@altinn:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_PAT}
-```
+### NPM
 
 Run `npm i @altinn/figma-design-tokens`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "change-case": "^4.1.2",
     "rimraf": "^3.0.2",
     "style-dictionary": "^3.7.1",
-    "token-transformer": "^0.0.24"
+    "token-transformer": "^0.0.25"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@ __metadata:
     change-case: ^4.1.2
     rimraf: ^3.0.2
     style-dictionary: ^3.7.1
-    token-transformer: ^0.0.24
+    token-transformer: ^0.0.25
   languageName: unknown
   linkType: soft
 
@@ -467,14 +467,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"token-transformer@npm:^0.0.24":
-  version: 0.0.24
-  resolution: "token-transformer@npm:0.0.24"
+"token-transformer@npm:^0.0.25":
+  version: 0.0.25
+  resolution: "token-transformer@npm:0.0.25"
   dependencies:
     yargs: ^17.4.1
   bin:
     token-transformer: index.js
-  checksum: 9fb7bc0b78a43d45471b4e2709b50a02b8626f6fb2259977798d970028b27f983744cfdf151383ca769159c63b1d1236196c5e68c81f3bffd03b3fca817d42f7
+  checksum: a4390c1e274de194f4c26dcac52bf9a080af72c986510f7ec1a00bc77f3d5ba6e720a4e4fd7563beb98d723ffdefb94ff2bd38a838d7602682e9849845bfd026
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- Change to npm feed for publishing the package, to avoid consumers having to authenticate againts github. This was time consuming and cofusing for developers.
