### PR TITLE
chore: add automated versioning calculation and changelog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,15 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: "The type of release (one of 'patch', 'minor', or 'major')"
+        description: "'auto' should be preferred in most cases, see README for details"
         required: true
-        default: minor
+        default: auto
         type: choice
         options:
-        - patch
-        - minor
-        - major
+          - auto
+          - patch
+          - minor
+          - major
 
 jobs:
   build_release:
@@ -21,15 +22,15 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          fetch-depth: 0 # Need access to history for comparing previous releases
           ref: ${{ github.head_ref }}
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
-          registry-url: "https://npm.pkg.github.com"
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -37,14 +38,16 @@ jobs:
       - name: Build
         run: yarn run build
 
-      - name: Prepare release version
-        if: ${{ ! github.event.after }}
+      - name: Test
+        run: yarn run test
+
+      - name: Create new version
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          npm version ${{ github.event.inputs.release_type }}
+          yarn run create-release
           echo "release_version=`git describe`" >> $GITHUB_ENV
-          git push --follow-tags
 
       - name: Publish npm package
         run: yarn npm publish --access public
@@ -60,3 +63,4 @@ jobs:
           release_name: Release ${{ env.release_version }}
           draft: false
           prerelease: false
+          body_path: ./changes.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built files
 /dist/
+changes.md
 
 # Yarn stuff; we're not using PnP/Zero installs
 .pnp.*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or use the tokens as a module:
 ```jsx
 import tokens from "@altinn/figma-design-tokens";
 
-const Foo = () => <div style={{ padding: tokens.SpaceStandard }}>Hi</div>
+const Foo = () => <div style={{ padding: tokens.SpaceStandard }}>Hi</div>;
 ```
 
 Or as JSON:
@@ -37,7 +37,9 @@ Or as JSON:
 ```jsx
 import tokens from "@altinn/figma-design-tokens/dist/tokens.json";
 
-const Foo = () => <div style={{ padding: tokens.space.standard.value }}>Hi</div>
+const Foo = () => (
+  <div style={{ padding: tokens.space.standard.value }}>Hi</div>
+);
 ```
 
 (Note that in TypeScript you'll want to set `resolveJsonModule: true` for the above to work.)
@@ -50,11 +52,11 @@ You should use Figma to edit the tokens. You'll need the [Figma Tokens](https://
 1. Generate a new Personal Access Token (PAT) in [GitHub Developer Settings](https://github.com/settings/tokens) with scope `repo`
 1. Copy the PAT (you can only see it once)
 1. In the Figma Tokens plugin, under `Sync > GitHub`, add new credentials:
-    - Name: `Altinn Figma Tokens`
-    - Personal Access Token: *your PAT*
-    - Repository: `Altinn/figma-design-tokens`
-    - Default Branch: `main`
-    - File Path: `tokens.json`
+   - Name: `Altinn Figma Tokens`
+   - Personal Access Token: _your PAT_
+   - Repository: `Altinn/figma-design-tokens`
+   - Default Branch: `main`
+   - File Path: `tokens.json`
 
 You can now "pull from GitHub" (button on top right) to fetch the tokens. When done editing tokens, you should "push to GitHub" (second button on top right).
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ You can now "pull from GitHub" (button on top right) to fetch the tokens. When d
 
 ## Releasing a new version
 
-There may have been tokens that have been renamed or removed, which means consumers of this package need to take action before upgrading. So before creating a new version, be sure to **check the commit history for breaking changes**.
+Go to Github Actions, and trigger a new Release. For most cases, `auto` should be the preferred option. This will automatically identify breaking changes, new features, or changed values between previous release and the current release. A changelog with the differences will also be created and added to the release.
 
-For now this is a manual process. Look at the [commit history](https://github.com/Altinn/figma-design-tokens/commits/main) for the main branch, and inspect the commits up until the previous tagged commit.
-
-Then go to the Github Actions, and trigger a new Release with the correct version bump. If there is a breaking change, release it as a major version. If there is no breaking changes, release it as a minor version.
+There may be edge cases where you want to force the release to be of a certain type, where you can select one of the other options.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "packageManager": "yarn@3.2.0",
   "devDependencies": {
     "change-case": "^4.1.2",
+    "execa": "^6.1.0",
+    "json-diff": "^0.9.0",
     "rimraf": "^3.0.2",
     "style-dictionary": "^3.7.1",
     "token-transformer": "^0.0.25"
@@ -17,7 +19,9 @@
   "scripts": {
     "build": "yarn run clean && yarn run generate-json && yarn run generate-others",
     "clean": "rimraf dist",
+    "test": "node scripts/create-release-utils.test.mjs",
     "generate-json": "token-transformer tokens.json dist/tokens.json --expandTypography",
+    "create-release": "node scripts/create-release.mjs",
     "generate-others": "style-dictionary build"
   }
 }

--- a/scripts/create-release-utils.mjs
+++ b/scripts/create-release-utils.mjs
@@ -1,0 +1,172 @@
+import fs from "node:fs";
+import jsonDiff from "json-diff";
+import { execa } from "execa";
+
+const deletedIdentifier = "__deleted";
+const addedIdentifier = "__added";
+const newIdentifier = "__new";
+const oldIdentifier = "__old";
+
+export const getValueByPath = (obj, path) =>
+  path.split(".").reduce((node, i) => node[i], obj);
+
+export const getChanges = ({ prevTokens, currentTokens }) => {
+  const diff = jsonDiff.diff(prevTokens, currentTokens, { full: true });
+
+  const breakingChanges = [];
+  const newChanges = [];
+  const patchChanges = [];
+
+  const getNewValues = (tokens, initialPath = "") => {
+    const newValues = [];
+
+    const traverseAndIdentifyNewChanges = (t, pathToKey = "") => {
+      for (const [key, value] of Object.entries(t)) {
+        if (typeof value === "object") {
+          traverseAndIdentifyNewChanges(value, `${pathToKey}${key}.`);
+        } else {
+          newValues.push(
+            `\`${pathToKey}.${key}\` has been added with the value: \`${value}\``
+          );
+        }
+      }
+    };
+
+    traverseAndIdentifyNewChanges(tokens, initialPath);
+
+    return newValues;
+  };
+
+  const traverseTokensAndIdentifyChanges = (tokens, pathToKey = "") => {
+    for (const [key, value] of Object.entries(tokens)) {
+      if (typeof value === "object") {
+        traverseTokensAndIdentifyChanges(value, `${pathToKey}${key}.`);
+      }
+
+      if (key.endsWith(newIdentifier)) {
+        const path = pathToKey.substring(0, pathToKey.length - 1); // Remove final period
+        const oldValue = getValueByPath(diff, path)[oldIdentifier];
+
+        patchChanges.push(
+          `\`${path}\` value has changed from \`${oldValue}\` to \`${value}\``
+        );
+      }
+
+      if (key.endsWith(deletedIdentifier)) {
+        breakingChanges.push(
+          `\`${pathToKey}${key.replace(
+            deletedIdentifier,
+            ""
+          )}\` has been removed`
+        );
+      }
+
+      if (key.endsWith(addedIdentifier)) {
+        const cleanedKey = key.replace(addedIdentifier, "");
+        if (typeof value === "object") {
+          newChanges.push(...getNewValues(value, `${pathToKey}${cleanedKey}`));
+        } else {
+          newChanges.push(
+            `\`${pathToKey}${cleanedKey}\` has been added with the value: \`${value}\``
+          );
+        }
+      }
+    }
+  };
+
+  if (diff) {
+    traverseTokensAndIdentifyChanges(diff);
+  }
+
+  return { breakingChanges, newChanges, patchChanges };
+};
+
+export const printChangesToFile = ({ breakingChanges, newChanges, patchChanges }) => {
+  let file;
+  try {
+    file = fs.createWriteStream("./changes.md");
+
+    if (
+      breakingChanges.length === 0 &&
+      newChanges.length === 0 &&
+      patchChanges.length === 0
+    ) {
+      file.write("_No token changes in this release_");
+    } else {
+      if (patchChanges.length > 0) {
+        file.write("## 🐛 Fixes:\n");
+        patchChanges.forEach((change) => file.write(`- ${change}\n`));
+        file.write("\n");
+      }
+
+      if (newChanges.length > 0) {
+        file.write("## ✨ New features:\n");
+        newChanges.forEach((change) => file.write(`- ${change}\n`));
+        file.write("\n");
+      }
+
+      if (breakingChanges.length > 0) {
+        file.write("## 💣 Breaking changes:\n");
+        breakingChanges.forEach((change) => file.write(`- ${change}\n`));
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  } finally {
+    file.end();
+  }
+};
+
+export const readTokenFile = async ({ revision }) => {
+  const { stdout } = await execa("git", ["show", `${revision}:tokens.json`]);
+  return JSON.parse(stdout);
+};
+
+export const getPreviousTag = async () => {
+  const { stdout } = await execa("git", ["describe", "--tags", "--abbrev=0"]);
+  return stdout;
+};
+
+export const checkEnv = () => {
+  if (!process.env.GITHUB_ACTOR) {
+    throw new Error(
+      "This script should only be run in the context of a github workflow"
+    );
+  }
+};
+
+export const getNewVersionArg = ({ breakingChanges, newChanges }) => {
+  const releaseType = process.env.RELEASE_TYPE;
+  const validReleaseTypes = ["major", "minor", "patch", "auto"];
+  if (!validReleaseTypes.includes(releaseType)) {
+    throw new Error(
+      `Release type should be one of ${validReleaseTypes.join(", ")}`
+    );
+  }
+
+  if (releaseType === "auto") {
+    if (breakingChanges.length > 0) {
+      return "major";
+    }
+    if (newChanges.length > 0) {
+      return "minor";
+    }
+
+    return "patch";
+  }
+
+  return releaseType;
+};
+
+export const createVersionCommit = async ({ breakingChanges, newChanges }) => {
+  const newVersionArg = getNewVersionArg({ breakingChanges, newChanges });
+  const author = process.env.GITHUB_ACTOR;
+  await execa("git", ["config", "user.name", author]);
+  await execa("git", [
+    "config",
+    "user.email",
+    `${author}@users.noreply.github.com`,
+  ]);
+  await execa("npm", ["version", newVersionArg]);
+};

--- a/scripts/create-release-utils.test.mjs
+++ b/scripts/create-release-utils.test.mjs
@@ -1,0 +1,221 @@
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkEnv,
+  getNewVersionArg,
+  getChanges,
+} from "./create-release-utils.mjs";
+
+describe("checkEnv", () => {
+  test("should throw when env.GITHUB_ACTOR is not set", () => {
+    const actor = process.env.GITHUB_ACTOR;
+    delete process.env.GITHUB_ACTOR;
+    assert.throws(() => {
+      checkEnv();
+    }, Error);
+    process.env.GITHUB_ACTOR = actor;
+  });
+
+  test("should not throw when env.GITHUB_ACTOR is set", () => {
+    const actor = process.env.GITHUB_ACTOR;
+    process.env.GITHUB_ACTOR = "test";
+    assert.doesNotThrow(() => {
+      checkEnv();
+    });
+    process.env.GITHUB_ACTOR = actor;
+  });
+});
+
+describe("getNewVersionArg", () => {
+  test("should return major when env.RELEASE_TYPE is auto and there are breaking changes", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "auto";
+    assert.strictEqual(
+      getNewVersionArg({
+        breakingChanges: ["breaking change"],
+        newChanges: [],
+      }),
+      "major"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return major when env.RELEASE_TYPE is auto and there are breaking changes and new features", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "auto";
+    assert.strictEqual(
+      getNewVersionArg({
+        breakingChanges: ["breaking change"],
+        newChanges: ["new feature"],
+      }),
+      "major"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return minor when env.RELEASE_TYPE is auto and there are no breaking changes, only new features", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "auto";
+    assert.strictEqual(
+      getNewVersionArg({ breakingChanges: [], newChanges: ["new feature"] }),
+      "minor"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return patch when env.RELEASE_TYPE is auto and there are no breaking changes and no new features", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "auto";
+    assert.strictEqual(
+      getNewVersionArg({ breakingChanges: [], newChanges: [] }),
+      "patch"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return major when env.RELEASE_TYPE is major even when there are no breaking changes", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "major";
+    assert.strictEqual(
+      getNewVersionArg({ breakingChanges: [], newChanges: [] }),
+      "major"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return minor when env.RELEASE_TYPE is minor even when there are breaking changes", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "minor";
+    assert.strictEqual(
+      getNewVersionArg({
+        breakingChanges: ["breaking changes"],
+        newChanges: [],
+      }),
+      "minor"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return patch when env.RELEASE_TYPE is patch even when there are breaking changes", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "patch";
+    assert.strictEqual(
+      getNewVersionArg({
+        breakingChanges: ["breaking change"],
+        newChanges: [],
+      }),
+      "patch"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should return patch when env.RELEASE_TYPE is patch", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "patch";
+    assert.strictEqual(
+      getNewVersionArg({ breakingChanges: [], newChanges: [] }),
+      "patch"
+    );
+    process.env.RELEASE_TYPE = releaseType;
+  });
+
+  test("should throw when env.RELEASE_TYPE is not a known keyword", () => {
+    const releaseType = process.env.RELEASE_TYPE;
+    process.env.RELEASE_TYPE = "banana";
+    assert.throws(() => {
+      getNewVersionArg({ breakingChanges: [], newChanges: [] });
+    }, Error);
+    process.env.RELEASE_TYPE = releaseType;
+  });
+});
+
+describe("getChanges", () => {
+  test("should identify breaking changes when properties have been removed", () => {
+    const prevTokens = {
+      foo: {
+        bar: "baz",
+      },
+      fizz: {
+        buzz: "bazz",
+      },
+    };
+    const currentTokens = {
+      foo: {
+        bar: "baz",
+      },
+    };
+    const result = getChanges({ prevTokens, currentTokens });
+
+    const expected = {
+      breakingChanges: ["`fizz` has been removed"],
+      newChanges: [],
+      patchChanges: [],
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  test("should identify new features changes when properties have been added", () => {
+    const prevTokens = {
+      foo: {
+        bar: "baz",
+      },
+      fizz: {
+        buzz: "bazz",
+      },
+    };
+    const currentTokens = {
+      foo: {
+        bar: "baz",
+      },
+      fizz: {
+        buzz: "bazz",
+        bar: "baz",
+      },
+      fruit: "banana",
+    };
+    const result = getChanges({ prevTokens, currentTokens });
+
+    const expected = {
+      breakingChanges: [],
+      newChanges: [
+        "`fruit` has been added with the value: `banana`",
+        "`fizz.bar` has been added with the value: `baz`",
+      ],
+      patchChanges: [],
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  test("should identify patch changes when property values have been modified", () => {
+    const prevTokens = {
+      foo: {
+        bar: "baz",
+      },
+      fizz: {
+        buzz: "bazz",
+      },
+    };
+    const currentTokens = {
+      foo: {
+        bar: "baz2",
+      },
+      fizz: {
+        buzz: "bazz2",
+      },
+    };
+    const result = getChanges({ prevTokens, currentTokens });
+
+    const expected = {
+      breakingChanges: [],
+      newChanges: [],
+      patchChanges: [
+        "`foo.bar` value has changed from `baz` to `baz2`",
+        "`fizz.buzz` value has changed from `bazz` to `bazz2`",
+      ],
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+});

--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -1,0 +1,36 @@
+import { execa } from "execa";
+
+import {
+  readTokenFile,
+  checkEnv,
+  getPreviousTag,
+  getChanges,
+  printChangesToFile,
+  createVersionCommit,
+} from "./create-release-utils.mjs";
+
+const start = async () => {
+  try {
+    checkEnv();
+    const prevTag = await getPreviousTag();
+    const currentTokens = await readTokenFile({ revision: "HEAD" });
+    const prevTokens = await readTokenFile({ revision: prevTag });
+
+    const { breakingChanges, newChanges, patchChanges } = getChanges({
+      prevTokens,
+      currentTokens,
+    });
+
+    printChangesToFile({ breakingChanges, newChanges, patchChanges });
+    await createVersionCommit({ breakingChanges, newChanges });
+    await execa("git", ["push", "--follow-tags"]);
+  } catch (error) {
+    console.log(
+      "Something unexpected happened when trying to create a release"
+    );
+    console.log(error);
+    process.exit(1);
+  }
+};
+
+start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,8 @@ __metadata:
   resolution: "@altinn/figma-design-tokens@workspace:."
   dependencies:
     change-case: ^4.1.2
+    execa: ^6.1.0
+    json-diff: ^0.9.0
     rimraf: ^3.0.2
     style-dictionary: ^3.7.1
     token-transformer: ^0.0.25
@@ -100,6 +102,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-color@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "cli-color@npm:2.0.3"
+  dependencies:
+    d: ^1.0.1
+    es5-ext: ^0.10.61
+    es6-iterator: ^2.0.3
+    memoizee: ^0.4.15
+    timers-ext: ^0.1.7
+  checksum: b1c5f3d0ec29cbe22be7a01d90bd0cfa080ffed6f1c321ea20ae3f10c6041f0e411e28ee2b98025945bee3548931deed1ae849b53c21b523ba74efef855cd73d
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -152,6 +167,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-spawn@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-spawn@npm:7.0.3"
+  dependencies:
+    path-key: ^3.1.0
+    shebang-command: ^2.0.0
+    which: ^2.0.1
+  checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"d@npm:1, d@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "d@npm:1.0.1"
+  dependencies:
+    es5-ext: ^0.10.50
+    type: ^1.0.1
+  checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
+  languageName: node
+  linkType: hard
+
+"difflib@npm:~0.2.1":
+  version: 0.2.4
+  resolution: "difflib@npm:0.2.4"
+  dependencies:
+    heap: ">= 0.2.0"
+  checksum: 4f4237b026263ce7471b77d9019b901c2f358a7da89401a80a84a8c3cdc1643a8e70b7495ccbe686cb4d95492eaf5dac119cd9ecbffe5f06bfc175fbe5c20a27
+  languageName: node
+  linkType: hard
+
 "dot-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "dot-case@npm:3.0.4"
@@ -162,6 +207,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dreamopt@npm:~0.8.0":
+  version: 0.8.0
+  resolution: "dreamopt@npm:0.8.0"
+  dependencies:
+    wordwrap: ">=0.0.2"
+  checksum: 701134807c4a2cc6d111888e1faa7ea6b5ac73cb2cc0f49d852844f7ade3f8bfd03249845841ff2786ffeb6cff9ba8d8cf39c152c24341fd67ef93a0cf7c9287
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -169,10 +223,90 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.46, es5-ext@npm:^0.10.50, es5-ext@npm:^0.10.53, es5-ext@npm:^0.10.61, es5-ext@npm:~0.10.14, es5-ext@npm:~0.10.2, es5-ext@npm:~0.10.46":
+  version: 0.10.62
+  resolution: "es5-ext@npm:0.10.62"
+  dependencies:
+    es6-iterator: ^2.0.3
+    es6-symbol: ^3.1.3
+    next-tick: ^1.1.0
+  checksum: 25f42f6068cfc6e393cf670bc5bba249132c5f5ec2dd0ed6e200e6274aca2fed8e9aec8a31c76031744c78ca283c57f0b41c7e737804c6328c7b8d3fbcba7983
+  languageName: node
+  linkType: hard
+
+"es6-iterator@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es6-iterator@npm:2.0.3"
+  dependencies:
+    d: 1
+    es5-ext: ^0.10.35
+    es6-symbol: ^3.1.1
+  checksum: 6e48b1c2d962c21dee604b3d9f0bc3889f11ed5a8b33689155a2065d20e3107e2a69cc63a71bd125aeee3a589182f8bbcb5c8a05b6a8f38fa4205671b6d09697
+  languageName: node
+  linkType: hard
+
+"es6-symbol@npm:^3.1.1, es6-symbol@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "es6-symbol@npm:3.1.3"
+  dependencies:
+    d: ^1.0.1
+    ext: ^1.1.2
+  checksum: cd49722c2a70f011eb02143ef1c8c70658d2660dead6641e160b94619f408b9cf66425515787ffe338affdf0285ad54f4eae30ea5bd510e33f8659ec53bcaa70
+  languageName: node
+  linkType: hard
+
+"es6-weak-map@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es6-weak-map@npm:2.0.3"
+  dependencies:
+    d: 1
+    es5-ext: ^0.10.46
+    es6-iterator: ^2.0.3
+    es6-symbol: ^3.1.1
+  checksum: 19ca15f46d50948ce78c2da5f21fb5b1ef45addd4fe17b5df952ff1f2a3d6ce4781249bc73b90995257264be2a98b2ec749bb2aba0c14b5776a1154178f9c927
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
+  languageName: node
+  linkType: hard
+
+"event-emitter@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "event-emitter@npm:0.3.5"
+  dependencies:
+    d: 1
+    es5-ext: ~0.10.14
+  checksum: 27c1399557d9cd7e0aa0b366c37c38a4c17293e3a10258e8b692a847dd5ba9fb90429c3a5a1eeff96f31f6fa03ccbd31d8ad15e00540b22b22f01557be706030
+  languageName: node
+  linkType: hard
+
+"execa@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "execa@npm:6.1.0"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.1
+    human-signals: ^3.0.1
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^3.0.7
+    strip-final-newline: ^3.0.0
+  checksum: 1a4af799839134f5c72eb63d525b87304c1114a63aa71676c91d57ccef2e26f2f53e14c11384ab11c4ec479be1efa83d11c8190e00040355c2c5c3364327fa8e
+  languageName: node
+  linkType: hard
+
+"ext@npm:^1.1.2":
+  version: 1.6.0
+  resolution: "ext@npm:1.6.0"
+  dependencies:
+    type: ^2.5.0
+  checksum: ca3ef4619e838f441a92238a98b77ac873da2175ace746c64303ffe2c3208e79a3acf3bf7004e40b720f3c2a83bf0143e6dd4a7cdfae6e73f54a3bfc7a14b5c2
   languageName: node
   linkType: hard
 
@@ -198,6 +332,13 @@ __metadata:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "get-stream@npm:6.0.1"
+  checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
   languageName: node
   linkType: hard
 
@@ -239,6 +380,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"heap@npm:>= 0.2.0":
+  version: 0.2.7
+  resolution: "heap@npm:0.2.7"
+  checksum: b0f3963a799e02173f994c452921a777f2b895b710119df999736bfed7477235c2860c423d9aea18a9f3b3d065cb1114d605c208cfcb8d0ac550f97ec5d28cb0
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "human-signals@npm:3.0.1"
+  checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -260,6 +415,40 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "is-promise@npm:2.2.2"
+  checksum: 18bf7d1c59953e0ad82a1ed963fb3dc0d135c8f299a14f89a17af312fc918373136e56028e8831700e1933519630cc2fd4179a777030330fde20d34e96f40c78
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
+  languageName: node
+  linkType: hard
+
+"isexe@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "isexe@npm:2.0.0"
+  checksum: 26bf6c5480dda5161c820c5b5c751ae1e766c587b1f951ea3fcfc973bafb7831ae5b54a31a69bd670220e42e99ec154475025a468eae58ea262f813fdc8d1c62
+  languageName: node
+  linkType: hard
+
+"json-diff@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "json-diff@npm:0.9.0"
+  dependencies:
+    cli-color: ^2.0.0
+    difflib: ~0.2.1
+    dreamopt: ~0.8.0
+  bin:
+    json-diff: bin/json-diff.js
+  checksum: c553da0e461ad940c50922c6939a8842930bf1a107dcfb4293cd79ab317cd405c0cc9d10013cc9c8bf47cab7dacdc1b72b17734b38ae23822088e980ca7aa0ae
   languageName: node
   linkType: hard
 
@@ -308,12 +497,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "lru-queue@npm:0.1.0"
+  dependencies:
+    es5-ext: ~0.10.2
+  checksum: 7f2c53c5e7f2de20efb6ebb3086b7aea88d6cf9ae91ac5618ece974122960c4e8ed04988e81d92c3e63d60b12c556b14d56ef7a9c5a4627b23859b813e39b1a2
+  languageName: node
+  linkType: hard
+
+"memoizee@npm:^0.4.15":
+  version: 0.4.15
+  resolution: "memoizee@npm:0.4.15"
+  dependencies:
+    d: ^1.0.1
+    es5-ext: ^0.10.53
+    es6-weak-map: ^2.0.3
+    event-emitter: ^0.3.5
+    is-promise: ^2.2.2
+    lru-queue: ^0.1.0
+    next-tick: ^1.1.0
+    timers-ext: ^0.1.7
+  checksum: 4065d94416dbadac56edf5947bf342beca0e9f051f33ad60d7c4baf3f6ca0f3c6fdb770c5caed5a89c0ceaf9121428582f396445d591785281383d60aa883418
+  languageName: node
+  linkType: hard
+
+"merge-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-stream@npm:2.0.0"
+  checksum: 6fa4dcc8d86629705cea944a4b88ef4cb0e07656ebf223fa287443256414283dd25d91c1cd84c77987f2aec5927af1a9db6085757cb43d90eb170ebf4b47f4f4
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-fn@npm:4.0.0"
+  checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: ^1.1.7
   checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  languageName: node
+  linkType: hard
+
+"next-tick@npm:1, next-tick@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "next-tick@npm:1.1.0"
+  checksum: 83b5cf36027a53ee6d8b7f9c0782f2ba87f4858d977342bfc3c20c21629290a2111f8374d13a81221179603ffc4364f38374b5655d17b6a8f8a8c77bdea4fe8b
   languageName: node
   linkType: hard
 
@@ -327,12 +562,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "npm-run-path@npm:5.1.0"
+  dependencies:
+    path-key: ^4.0.0
+  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "onetime@npm:6.0.0"
+  dependencies:
+    mimic-fn: ^4.0.0
+  checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
   languageName: node
   linkType: hard
 
@@ -373,6 +626,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-key@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "path-key@npm:3.1.1"
+  checksum: 55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
+  languageName: node
+  linkType: hard
+
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
@@ -399,6 +666,29 @@ __metadata:
     tslib: ^2.0.3
     upper-case-first: ^2.0.2
   checksum: 3cfe6c0143e649132365695706702d7f729f484fa7b25f43435876efe7af2478243eefb052bacbcce10babf9319fd6b5b6bc59b94c80a1c819bcbb40651465d5
+  languageName: node
+  linkType: hard
+
+"shebang-command@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "shebang-command@npm:2.0.0"
+  dependencies:
+    shebang-regex: ^3.0.0
+  checksum: 6b52fe87271c12968f6a054e60f6bde5f0f3d2db483a1e5c3e12d657c488a15474121a1d55cd958f6df026a54374ec38a4a963988c213b7570e1d51575cea7fa
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "shebang-regex@npm:3.0.0"
+  checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "signal-exit@npm:3.0.7"
+  checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
   languageName: node
   linkType: hard
 
@@ -432,6 +722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-final-newline@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-final-newline@npm:3.0.0"
+  checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
+  languageName: node
+  linkType: hard
+
 "style-dictionary@npm:^3.7.1":
   version: 3.7.1
   resolution: "style-dictionary@npm:3.7.1"
@@ -460,6 +757,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"timers-ext@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "timers-ext@npm:0.1.7"
+  dependencies:
+    es5-ext: ~0.10.46
+    next-tick: 1
+  checksum: ef3f27a0702a88d885bcbb0317c3e3ecd094ce644da52e7f7d362394a125d9e3578292a8f8966071a980d8abbc3395725333b1856f3ae93835b46589f700d938
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.4.1":
   version: 1.4.2
   resolution: "tinycolor2@npm:1.4.2"
@@ -485,6 +792,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type@npm:^1.0.1":
+  version: 1.2.0
+  resolution: "type@npm:1.2.0"
+  checksum: dae8c64f82c648b985caf321e9dd6e8b7f4f2e2d4f846fc6fd2c8e9dc7769382d8a52369ddbaccd59aeeceb0df7f52fb339c465be5f2e543e81e810e413451ee
+  languageName: node
+  linkType: hard
+
+"type@npm:^2.5.0":
+  version: 2.7.2
+  resolution: "type@npm:2.7.2"
+  checksum: 0f42379a8adb67fe529add238a3e3d16699d95b42d01adfe7b9a7c5da297f5c1ba93de39265ba30ffeb37dfd0afb3fb66ae09f58d6515da442219c086219f6f4
+  languageName: node
+  linkType: hard
+
 "universalify@npm:^2.0.0":
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
@@ -507,6 +828,24 @@ __metadata:
   dependencies:
     tslib: ^2.0.3
   checksum: 508723a2b03ab90cf1d6b7e0397513980fab821cbe79c87341d0e96cedefadf0d85f9d71eac24ab23f526a041d585a575cfca120a9f920e44eb4f8a7cf89121c
+  languageName: node
+  linkType: hard
+
+"which@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "which@npm:2.0.2"
+  dependencies:
+    isexe: ^2.0.0
+  bin:
+    node-which: ./bin/node-which
+  checksum: 1a5c563d3c1b52d5f893c8b61afe11abc3bab4afac492e8da5bde69d550de701cf9806235f20a47b5c8fa8a1d6a9135841de2596535e998027a54589000e66d1
+  languageName: node
+  linkType: hard
+
+"wordwrap@npm:>=0.0.2":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 2a44b2788165d0a3de71fd517d4880a8e20ea3a82c080ce46e294f0b68b69a2e49cff5f99c600e275c698a90d12c5ea32aff06c311f0db2eb3f1201f3e7b2a04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Keeping track of what has changed, and potential changes in this repo has been a manual pain.

This change will compare the tokens.json with the previously released tokens.json file, and calculate if the changes are major, minor or patch. It will also generate a changelog with the details of which keys/values has been added/removed/changed.

## Related Issue(s)
- fixes #11
