### PR TITLE
chore: fix double dot between properties in changelog

### DIFF
--- a/scripts/create-release-utils.mjs
+++ b/scripts/create-release-utils.mjs
@@ -133,13 +133,7 @@ export const getPreviousTag = async () => {
   return stdout;
 };
 
-export const checkEnv = () => {
-  if (!process.env.GITHUB_ACTOR) {
-    throw new Error(
-      "This script should only be run in the context of a github workflow"
-    );
-  }
-};
+export const checkEnv = () => Boolean(process.env.GITHUB_ACTOR);
 
 export const getNewVersionArg = ({ breakingChanges, newChanges }) => {
   const releaseType = process.env.RELEASE_TYPE;

--- a/scripts/create-release-utils.mjs
+++ b/scripts/create-release-utils.mjs
@@ -26,7 +26,7 @@ export const getChanges = ({ prevTokens, currentTokens }) => {
           traverseAndIdentifyNewChanges(value, `${pathToKey}${key}.`);
         } else {
           newValues.push(
-            `\`${pathToKey}.${key}\` has been added with the value: \`${value}\``
+            `\`${pathToKey}${key}\` has been added with the value: \`${value}\``
           );
         }
       }
@@ -63,8 +63,9 @@ export const getChanges = ({ prevTokens, currentTokens }) => {
 
       if (key.endsWith(addedIdentifier)) {
         const cleanedKey = key.replace(addedIdentifier, "");
+
         if (typeof value === "object") {
-          newChanges.push(...getNewValues(value, `${pathToKey}${cleanedKey}`));
+          newChanges.push(...getNewValues(value, `${pathToKey}${cleanedKey}.`));
         } else {
           newChanges.push(
             `\`${pathToKey}${cleanedKey}\` has been added with the value: \`${value}\``

--- a/scripts/create-release-utils.mjs
+++ b/scripts/create-release-utils.mjs
@@ -4,8 +4,8 @@ import { execa } from "execa";
 
 const deletedIdentifier = "__deleted";
 const addedIdentifier = "__added";
-const newIdentifier = "__new";
-const oldIdentifier = "__old";
+const newValueIdentifier = "__new";
+const oldValueIdentifier = "__old";
 
 export const getValueByPath = (obj, path) =>
   path.split(".").reduce((node, i) => node[i], obj);
@@ -43,9 +43,9 @@ export const getChanges = ({ prevTokens, currentTokens }) => {
         traverseTokensAndIdentifyChanges(value, `${pathToKey}${key}.`);
       }
 
-      if (key.endsWith(newIdentifier)) {
+      if (key.endsWith(newValueIdentifier)) {
         const path = pathToKey.substring(0, pathToKey.length - 1); // Remove final period
-        const oldValue = getValueByPath(diff, path)[oldIdentifier];
+        const oldValue = getValueByPath(diff, path)[oldValueIdentifier];
 
         patchChanges.push(
           `\`${path}\` value has changed from \`${oldValue}\` to \`${value}\``
@@ -81,7 +81,11 @@ export const getChanges = ({ prevTokens, currentTokens }) => {
   return { breakingChanges, newChanges, patchChanges };
 };
 
-export const printChangesToFile = ({ breakingChanges, newChanges, patchChanges }) => {
+export const printChangesToFile = ({
+  breakingChanges,
+  newChanges,
+  patchChanges,
+}) => {
   let file;
   try {
     file = fs.createWriteStream("./changes.md");

--- a/scripts/create-release-utils.test.mjs
+++ b/scripts/create-release-utils.test.mjs
@@ -1,4 +1,4 @@
-import test, { describe } from "node:test";
+import { it, describe } from "node:test";
 import assert from "node:assert/strict";
 import {
   checkEnv,
@@ -7,27 +7,23 @@ import {
 } from "./create-release-utils.mjs";
 
 describe("checkEnv", () => {
-  test("should throw when env.GITHUB_ACTOR is not set", () => {
+  it("should return false env.GITHUB_ACTOR is not set", () => {
     const actor = process.env.GITHUB_ACTOR;
     delete process.env.GITHUB_ACTOR;
-    assert.throws(() => {
-      checkEnv();
-    }, Error);
+    assert.strictEqual(checkEnv(), false);
     process.env.GITHUB_ACTOR = actor;
   });
 
-  test("should not throw when env.GITHUB_ACTOR is set", () => {
+  it("should return true when env.GITHUB_ACTOR is set", () => {
     const actor = process.env.GITHUB_ACTOR;
     process.env.GITHUB_ACTOR = "test";
-    assert.doesNotThrow(() => {
-      checkEnv();
-    });
+    assert.strictEqual(checkEnv(), true);
     process.env.GITHUB_ACTOR = actor;
   });
 });
 
 describe("getNewVersionArg", () => {
-  test("should return major when env.RELEASE_TYPE is auto and there are breaking changes", () => {
+  it("should return major when env.RELEASE_TYPE is auto and there are breaking changes", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "auto";
     assert.strictEqual(
@@ -40,7 +36,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return major when env.RELEASE_TYPE is auto and there are breaking changes and new features", () => {
+  it("should return major when env.RELEASE_TYPE is auto and there are breaking changes and new features", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "auto";
     assert.strictEqual(
@@ -53,7 +49,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return minor when env.RELEASE_TYPE is auto and there are no breaking changes, only new features", () => {
+  it("should return minor when env.RELEASE_TYPE is auto and there are no breaking changes, only new features", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "auto";
     assert.strictEqual(
@@ -63,7 +59,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return patch when env.RELEASE_TYPE is auto and there are no breaking changes and no new features", () => {
+  it("should return patch when env.RELEASE_TYPE is auto and there are no breaking changes and no new features", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "auto";
     assert.strictEqual(
@@ -73,7 +69,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return major when env.RELEASE_TYPE is major even when there are no breaking changes", () => {
+  it("should return major when env.RELEASE_TYPE is major even when there are no breaking changes", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "major";
     assert.strictEqual(
@@ -83,7 +79,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return minor when env.RELEASE_TYPE is minor even when there are breaking changes", () => {
+  it("should return minor when env.RELEASE_TYPE is minor even when there are breaking changes", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "minor";
     assert.strictEqual(
@@ -96,7 +92,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return patch when env.RELEASE_TYPE is patch even when there are breaking changes", () => {
+  it("should return patch when env.RELEASE_TYPE is patch even when there are breaking changes", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "patch";
     assert.strictEqual(
@@ -109,7 +105,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should return patch when env.RELEASE_TYPE is patch", () => {
+  it("should return patch when env.RELEASE_TYPE is patch", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "patch";
     assert.strictEqual(
@@ -119,7 +115,7 @@ describe("getNewVersionArg", () => {
     process.env.RELEASE_TYPE = releaseType;
   });
 
-  test("should throw when env.RELEASE_TYPE is not a known keyword", () => {
+  it("should throw when env.RELEASE_TYPE is not a known keyword", () => {
     const releaseType = process.env.RELEASE_TYPE;
     process.env.RELEASE_TYPE = "banana";
     assert.throws(() => {
@@ -130,7 +126,7 @@ describe("getNewVersionArg", () => {
 });
 
 describe("getChanges", () => {
-  test("should identify breaking changes when properties have been removed", () => {
+  it("should identify breaking changes when properties have been removed", () => {
     const prevTokens = {
       foo: {
         bar: "baz",
@@ -138,16 +134,43 @@ describe("getChanges", () => {
       fizz: {
         buzz: "bazz",
       },
+      altinn: {
+        component: {
+          button: {
+            default: {
+              value: "red",
+              type: "color",
+            },
+            primary: {
+              value: "blue",
+              type: "color",
+            },
+          },
+        },
+      },
     };
     const currentTokens = {
       foo: {
         bar: "baz",
       },
+      altinn: {
+        component: {
+          button: {
+            default: {
+              value: "red",
+              type: "color",
+            },
+          },
+        },
+      },
     };
     const result = getChanges({ prevTokens, currentTokens });
 
     const expected = {
-      breakingChanges: ["`fizz` has been removed"],
+      breakingChanges: [
+        "`fizz` has been removed",
+        "`altinn.component.button.primary` has been removed",
+      ],
       newChanges: [],
       patchChanges: [],
     };
@@ -155,7 +178,7 @@ describe("getChanges", () => {
     assert.deepStrictEqual(result, expected);
   });
 
-  test("should identify new features changes when properties have been added", () => {
+  it("should identify new features changes when properties have been added", () => {
     const prevTokens = {
       foo: {
         bar: "baz",
@@ -173,6 +196,16 @@ describe("getChanges", () => {
         bar: "baz",
       },
       fruit: "banana",
+      altinn: {
+        component: {
+          button: {
+            default: {
+              value: "red",
+              type: "color",
+            },
+          },
+        },
+      },
     };
     const result = getChanges({ prevTokens, currentTokens });
 
@@ -180,6 +213,8 @@ describe("getChanges", () => {
       breakingChanges: [],
       newChanges: [
         "`fruit` has been added with the value: `banana`",
+        "`altinn.component.button.default.value` has been added with the value: `red`",
+        "`altinn.component.button.default.type` has been added with the value: `color`",
         "`fizz.bar` has been added with the value: `baz`",
       ],
       patchChanges: [],
@@ -188,13 +223,23 @@ describe("getChanges", () => {
     assert.deepStrictEqual(result, expected);
   });
 
-  test("should identify patch changes when property values have been modified", () => {
+  it("should identify patch changes when property values have been modified", () => {
     const prevTokens = {
       foo: {
         bar: "baz",
       },
       fizz: {
         buzz: "bazz",
+      },
+      altinn: {
+        component: {
+          button: {
+            default: {
+              value: "red",
+              type: "color",
+            },
+          },
+        },
       },
     };
     const currentTokens = {
@@ -203,6 +248,16 @@ describe("getChanges", () => {
       },
       fizz: {
         buzz: "bazz2",
+      },
+      altinn: {
+        component: {
+          button: {
+            default: {
+              value: "blue",
+              type: "color",
+            },
+          },
+        },
       },
     };
     const result = getChanges({ prevTokens, currentTokens });
@@ -213,6 +268,7 @@ describe("getChanges", () => {
       patchChanges: [
         "`foo.bar` value has changed from `baz` to `baz2`",
         "`fizz.buzz` value has changed from `bazz` to `bazz2`",
+        "`altinn.component.button.default.value` value has changed from `red` to `blue`",
       ],
     };
 


### PR DESCRIPTION
## Description
There was a dot added in the wrong place during changelog generation which only appeared when there were deeply nested properties. This has been fixed, and covered with tests.
